### PR TITLE
Fix jsonld label error

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -67,7 +67,7 @@
         manifold
           .loadManifest({
             manifestUri:
-              "https://figgy.princeton.edu/concern/scanned_resources/cfec680e-1169-475d-b0f3-90b5f64e8115/manifest ",
+              "http://wellcomelibrary.org/iiif/collection/b19974760",
             collectionIndex: 0,
             manifestIndex: 0,
             sequenceIndex: 0,

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,7 @@ export class TreeComponent extends BaseComponent {
 
           data.dir = "ltr";
 
-          if (data.data.__jsonld.label) {
+          if (data.data.__jsonld && data.data.__jsonld.label) {
             const lang: string = data.data.__jsonld.label["@language"];
 
             if (lang && that._data.rtlLanguageCodes.includes(lang.trim())) {


### PR DESCRIPTION
There seems to have been an issue since `v2.0.4`, at least in the umd version, where if the `__jsonld` property doesn't exist on line 109 the switch from the default view to date grouping will fail.

This PR adds an additional check to the `if()` to ensure it does before attempting to check/use `.label`

Additionally the example `index.html` file is changed to use an appropriate manifest for testing purposes.

I've not used optional chaining because the TS version doesn't seem to support it, but that's a separate issue.